### PR TITLE
Update feature to save converted files

### DIFF
--- a/src/main/java/io/jenkins/plugins/ml/model/ParsableFile.java
+++ b/src/main/java/io/jenkins/plugins/ml/model/ParsableFile.java
@@ -39,8 +39,6 @@ public class ParsableFile extends AbstractDescribableImpl<ParsableFile> {
 
     enum SourceCodeConvertType{
         // Type of source code to be handled by IPython builder
-        NBFORMAT,
-        ZFORMAT,
         JSON,
         PY,
         NONE
@@ -48,18 +46,16 @@ public class ParsableFile extends AbstractDescribableImpl<ParsableFile> {
 
     private final String fileName;
     private final boolean deleteFilesAfterBuild;
-    private final String sType;
+    private final String convertType;
+    private final String saveConverted;
 
 
     @DataBoundConstructor
-    public ParsableFile(String fileName, boolean deleteFilesAfterBuild, String sType) {
+    public ParsableFile(String fileName, boolean deleteFilesAfterBuild, String convertType, String saveConverted) {
         this.fileName = fileName;
         this.deleteFilesAfterBuild = deleteFilesAfterBuild;
-        this.sType = sType;
-    }
-
-    public String getsType() {
-        return sType;
+        this.convertType = convertType;
+        this.saveConverted = saveConverted;
     }
 
     public String getFileName() {
@@ -70,8 +66,16 @@ public class ParsableFile extends AbstractDescribableImpl<ParsableFile> {
         return deleteFilesAfterBuild;
     }
 
-    public static ListBoxModel.Option createOption(String jobName, Enum<?> enumOption) {
-        return new ListBoxModel.Option(jobName, enumOption.name());
+    public static ListBoxModel.Option createOption(String jobName, Enum<?> enumOption, String convertType) {
+        return new ListBoxModel.Option(jobName, enumOption.name(), enumOption.name().equals(convertType));
+    }
+
+    public String getConvertType() {
+        return convertType;
+    }
+
+    public String getSaveConverted() {
+        return saveConverted;
     }
 
     @Extension
@@ -79,18 +83,16 @@ public class ParsableFile extends AbstractDescribableImpl<ParsableFile> {
         @Nonnull
         @Override
         public String getDisplayName() {
-            return " File";
+            return "File";
         }
 
         // Fill the list box from the enum
         public ListBoxModel doFillConvertTypeItems(@QueryParameter String convertType) {
             ListBoxModel model = new ListBoxModel();
 
-            model.add(createOption("Jupyter Notebook",SourceCodeConvertType.NBFORMAT));
-            model.add(createOption("Zeppelin Notebook",SourceCodeConvertType.ZFORMAT));
-            model.add(createOption("JSON",SourceCodeConvertType.JSON));
-            model.add(createOption("Python",SourceCodeConvertType.PY));
-            model.add(createOption("None",SourceCodeConvertType.NONE));
+            model.add(createOption("None", SourceCodeConvertType.NONE, convertType));
+            model.add(createOption("JSON", SourceCodeConvertType.JSON, convertType));
+            model.add(createOption("Python", SourceCodeConvertType.PY, convertType));
 
             return model;
         }

--- a/src/main/resources/io/jenkins/plugins/ml/model/ParsableFile/help-convertType.html
+++ b/src/main/resources/io/jenkins/plugins/ml/model/ParsableFile/help-convertType.html
@@ -25,5 +25,5 @@
 <div>
   File type that the file will be converted
   <p>
-  Eg: JupyterNotebook
+    Eg: PY or JSON
 </div>

--- a/src/main/resources/io/jenkins/plugins/ml/model/ParsableFile/help-filePath.html
+++ b/src/main/resources/io/jenkins/plugins/ml/model/ParsableFile/help-filePath.html
@@ -23,7 +23,7 @@
 -->
 
 <div>
-  Provide notebook file path to copy to the workspace
+  Provide Jupyter notebook file path to copy to the workspace
   <p>
   Eg: /home/alice/iris_flower.ipynb
 </div>

--- a/src/main/resources/io/jenkins/plugins/ml/model/ParsableFile/help-saveConverted.html
+++ b/src/main/resources/io/jenkins/plugins/ml/model/ParsableFile/help-saveConverted.html
@@ -22,27 +22,8 @@
   ~ THE SOFTWARE.
 -->
 
-<?jelly escape-by-default='true'?>
-<j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
-    <f:entry title="${%File}" field="fileName">
-        <f:textbox/>
-    </f:entry>
-    <f:optionalBlock name="dynamic" title="Convert file" inline="true">
-        <f:entry title="Convert Type" field="convertType">
-            <f:select />
-        </f:entry>
-        <f:entry title="${%Save To}" field="saveConverted">
-            <f:textbox/>
-        </f:entry>
-        <f:entry title="${%Delete After Build}" field="deleteFilesAfterBuild">
-            <f:checkbox/>
-        </f:entry>
-    </f:optionalBlock>
-
-    <f:entry title="">
-        <div align="right">
-            <f:repeatableDeleteButton />
-        </div>
-    </f:entry>
-</j:jelly>
-
+<div>
+    File name with extension that will be converted
+    <p>
+        Eg: demo.json
+</div>


### PR DESCRIPTION
## [JENKINS-62711](https://issues.jenkins-ci.org/browse/JENKINS-62711) - Added feature to convert Jupyter Notebook files to JSON and python

- Removed redundant file types as Zeppelin use JSON to save a notebook.
- Optional conversion and deletion after build
- Copy jupyter notebook files with two types of conversion

1.  Python
2.  JSON ( Supported by Zeppelin) 

## Checklist

- [x] I have referenced the Jira issue related to my changes in one or more commit messages
- [x] Unit tests pass locally with my changes
- [ ] I have added documentation as necessary
- [x] No Javadoc warnings were introduced with my changes
- [x] No spotbugs warnings were introduced with my changes
- [x] I have interactively tested my changes

## Types of changes

- [ ] Infrastructure change (non-breaking change which updates dependencies or improves infrastructure)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
