### PR TITLE
Fix for file access from agent

### DIFF
--- a/src/main/java/io/jenkins/plugins/ml/FileParser.java
+++ b/src/main/java/io/jenkins/plugins/ml/FileParser.java
@@ -24,7 +24,6 @@
 
 package io.jenkins.plugins.ml;
 
-import com.google.gson.Gson;
 import com.google.gson.JsonObject;
 import hudson.Extension;
 import hudson.FilePath;
@@ -41,13 +40,8 @@ import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;
 
 import javax.annotation.Nonnull;
-import java.io.BufferedWriter;
 import java.io.File;
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
@@ -101,16 +95,11 @@ public class FileParser extends BuildWrapper {
                             } else {
                                 copyTo = new FilePath(workspace, file.getSaveConverted());
                             }
-                            // get the absolute path to write the JSON
-                            Path path = Paths.get(copyTo.getRemote());
+                            // get the obj to write the JSON
                             JsonObject obj = ConvertHelper.jupyterToJSON(copyFrom);
-                            try (BufferedWriter writer = Files.newBufferedWriter(path, StandardCharsets.UTF_8)) {
-                                // write to JSON
-                                Gson gson = new Gson();
-                                gson.toJson(obj, writer);
-                                listener.getLogger().println(String.format("%s copied and converted to %s", copyFrom.getName(), copyTo.getName()));
-                            }
-
+                            // write to JSON
+                            copyTo.write(obj.toString(), "UTF-8");
+                            listener.getLogger().println(String.format("%s copied and converted to %s", copyFrom.getName(), copyTo.getName()));
                             break;
                         case "PY":
                             // change the extension with same file name
@@ -119,15 +108,11 @@ public class FileParser extends BuildWrapper {
                             } else {
                                 copyTo = new FilePath(workspace, file.getSaveConverted());
                             }
-                            // get the absolute path to write the JSON
-                            Path path1 = Paths.get(copyTo.getRemote());
+                            // get the text to write the JSON
                             String code = ConvertHelper.jupyterToText(copyFrom);
-                            try (BufferedWriter writer = Files.newBufferedWriter(path1, StandardCharsets.UTF_8)) {
-                                // write to python file
-                                writer.write(code);
-                                listener.getLogger().println(String.format("%s copied and converted to %s", copyFrom.getName(), copyTo.getName()));
-                            }
-
+                            // write to python file
+                            copyTo.write(code, "UTF-8");
+                            listener.getLogger().println(String.format("%s copied and converted to %s", copyFrom.getName(), copyTo.getName()));
                             break;
                         default:
                             listener.getLogger().println("File conversion is not supported");


### PR DESCRIPTION
## [JENKINS-62735](https://issues.jenkins-ci.org/browse/JENKINS-62735) - JSON/Python can be written to agent workspace using `File path` write method. 

## Checklist

- [ ] I have referenced the Jira issue related to my changes in one or more commit messages
- [ ] Unit tests pass locally with my changes
- [ ] I have added documentation as necessary
- [ ] No Javadoc warnings were introduced with my changes
- [ ] No spotbugs warnings were introduced with my changes
- [ ] I have interactively tested my changes

## Types of changes

- [ ] Infrastructure change (non-breaking change which updates dependencies or improves infrastructure)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Further comments

![agent](https://user-images.githubusercontent.com/36206296/85312033-e9183b80-b4d3-11ea-95ba-503e93da4508.png)
