### PR TITLE
Fix for gson conflict in pom

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -206,10 +206,6 @@
             <plugin>
                 <groupId>org.jenkins-ci.tools</groupId>
                 <artifactId>maven-hpi-plugin</artifactId>
-                <configuration>
-                    <pluginFirstClassLoader>true</pluginFirstClassLoader>
-                    <minimumJavaVersion/>
-                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.apache.rat</groupId>


### PR DESCRIPTION
## [JENKINS-62681](https://issues.jenkins-ci.org/browse/JENKINS-62681) - pluginFirstClassLoader removed

As I had problem with the maven conflict between zeppelin and Jenkins core earlier, I used PluginFirstClassLoader to resolve that. I have already excluded the `guava` in Jenkins core. Hence, pluginFirstClassLoader can be removed. All the other code works fine and builds successfully.

## Checklist

- [x] I have referenced the Jira issue related to my changes in one or more commit messages
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No Javadoc warnings were introduced with my changes
- [x] No spotbugs warnings were introduced with my changes
- [x] I have interactively tested my changes

## Types of changes


- [ ] Infrastructure change (non-breaking change which updates dependencies or improves infrastructure)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

