### PR TITLE
Agent execution in failing due to JVM Gateway 

### DIFF
--- a/src/main/java/io/jenkins/plugins/ml/IPythonBuilder.java
+++ b/src/main/java/io/jenkins/plugins/ml/IPythonBuilder.java
@@ -80,12 +80,13 @@ public class IPythonBuilder extends Builder implements SimpleBuildStep, Serializ
             long launchTimeout = ipythonServerJobProperty.getServer().getLaunchTimeoutInMilliSeconds();
             long maxResults = ipythonServerJobProperty.getServer().getMaxResults();
             listener.getLogger().println("Executed server : " + serverName);
-            // create configuration
+            // Get the right channel to execute the code
             launcher.getChannel().call(new MasterToSlaveCallable<Void, Exception>() {
 
                 private static final long serialVersionUID = 1791985298575049757L;
                 @Override
                 public Void call() {
+                    // create configuration
                     IPythonUserConfig jobUserConfig = new IPythonUserConfig(serverAddress,launchTimeout,maxResults);
                     try ( IPythonInterpreterManager interpreterManager = new IPythonInterpreterManager(jobUserConfig)){
                         interpreterManager.initiateInterpreter();

--- a/src/main/java/io/jenkins/plugins/ml/IPythonUserConfig.java
+++ b/src/main/java/io/jenkins/plugins/ml/IPythonUserConfig.java
@@ -25,9 +25,10 @@
 package io.jenkins.plugins.ml;
 
 
+import java.io.Serializable;
 import java.util.Objects;
 
-public class IPythonUserConfig {
+public class IPythonUserConfig implements Serializable {
     private final String serverGatewayAddress;
     private final long iPythonLaunchTimeout;
     private final long maxResult;


### PR DESCRIPTION
## [JENKINS-62983](https://issues.jenkins-ci.org/browse/JENKINS-62983) - Agent failed to open a JVM Gateway

<!--Describe the big picture of your changes here to explain to the maintainers why this pull request should be accepted.-->
It fails to open a JVM Gateway in the agent. But it works in the master alone as we expected. I could not debug while it is running on an agent. This is a little start for the issue. We can discuss and solve it progressively.

Environment :
Master: Ubuntu 20.04 LTS
Agent : [ml-ssh-agent](https://hub.docker.com/repository/docker/loghijiaha/ml-ssh-agent)

```
Started by user unknown or anonymous
Running as SYSTEM
Building remotely on Agent (ki) in workspace /tmp/jenkins/workspace/demo
Executed server : EC2

Code Parser type : text
Executed code output : 

org.apache.zeppelin.interpreter.InterpreterException: org.apache.zeppelin.interpreter.InterpreterException:
 java.io.IOException: Fail to setup JVMGateway

	at org.apache.zeppelin.interpreter.LazyOpenInterpreter.open(LazyOpenInterpreter.java:76)
	at org.apache.zeppelin.interpreter.LazyOpenInterpreter.interpret(LazyOpenInterpreter.java:107)
	at io.jenkins.plugins.ml.IPythonKernelInterpreter.interpretCode(IPythonKernelInterpreter.java:78)
	at io.jenkins.plugins.ml.IPythonInterpreterManager.invokeInterpreter(IPythonInterpreterManager.java:90)
	at io.jenkins.plugins.ml.IPythonBuilder$1.call(IPythonBuilder.java:101)
	at io.jenkins.plugins.ml.IPythonBuilder$1.call(IPythonBuilder.java:89)
	at hudson.remoting.UserRequest.perform(UserRequest.java:212)
	at hudson.remoting.UserRequest.perform(UserRequest.java:54)
	at hudson.remoting.Request$2.run(Request.java:369)
	at hudson.remoting.InterceptingExecutorService$1.call(InterceptingExecutorService.java:72)
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
	at java.base/java.lang.Thread.run(Thread.java:834)
	Suppressed: hudson.remoting.Channel$CallSiteStackTrace: Remote call to Agent
		at hudson.remoting.Channel.attachCallSiteStackTrace(Channel.java:1743)
		at hudson.remoting.UserRequest$ExceptionResponse.retrieve(UserRequest.java:357)
		at hudson.remoting.Channel.call(Channel.java:957)
		at io.jenkins.plugins.ml.IPythonBuilder.perform(IPythonBuilder.java:89)
		at hudson.tasks.BuildStepCompatibilityLayer.perform(BuildStepCompatibilityLayer.java:79)
		at hudson.tasks.BuildStepMonitor$1.perform(BuildStepMonitor.java:20)
		at hudson.model.AbstractBuild$AbstractBuildExecution.perform(AbstractBuild.java:741)
		at hudson.model.Build$BuildExecution.build(Build.java:206)
		at hudson.model.Build$BuildExecution.doRun(Build.java:163)
		at hudson.model.AbstractBuild$AbstractBuildExecution.run(AbstractBuild.java:504)
		at hudson.model.Run.execute(Run.java:1818)
		at hudson.model.FreeStyleBuild.run(FreeStyleBuild.java:43)
		at hudson.model.ResourceController.execute(ResourceController.java:97)
		at hudson.model.Executor.run(Executor.java:429)
Caused by: org.apache.zeppelin.interpreter.InterpreterException: java.io.IOException: Fail to setup JVMGateway

	at org.apache.zeppelin.python.IPythonInterpreter.open(IPythonInterpreter.java:117)
	at org.apache.zeppelin.interpreter.LazyOpenInterpreter.open(LazyOpenInterpreter.java:70)
	... 13 more
Caused by: java.io.IOException: Fail to setup JVMGateway

	at org.apache.zeppelin.python.IPythonInterpreter.initPythonInterpreter(IPythonInterpreter.java:136)
	at org.apache.zeppelin.python.IPythonInterpreter.open(IPythonInterpreter.java:114)
	... 14 more
ERROR: org.apache.zeppelin.interpreter.InterpreterException: java.io.IOException: Fail to setup JVMGateway

Finished: FAILURE

```