### PR TITLE
Fix agent while running without a empty file path

### DIFF
--- a/src/main/java/io/jenkins/plugins/ml/FileParser.java
+++ b/src/main/java/io/jenkins/plugins/ml/FileParser.java
@@ -72,7 +72,7 @@ public class FileParser extends BuildWrapper {
         // Copy each file to the workspace
         projectWorkspace.ifPresent((workspace) -> {
             for (ParsableFile file : parsableFiles) {
-                FilePath copyFrom = new FilePath(new File(file.getFileName()));
+                FilePath copyFrom = workspace.child(file.getFileName());
                 FilePath copyTo;
                 LOGGER.info(String.format("Copying file from %s to %s", copyFrom.getName(), workspace.getName() + file.getSaveConverted()));
                 try {


### PR DESCRIPTION
## [JENKINS-63251](https://issues.jenkins-ci.org/browse/JENKINS-63251) - Fix for agent serializing errors

As we fixed in https://issues.jenkins-ci.org/browse/JENKINS-63128 to set the build failure when the plugin runs without a file given. This fix for both converting Jupyter files to python in agent and agent serialization error.

Refactoring will reduce the complexity of the perform method.

<!--Describe the big picture of your changes here to explain to the maintainers why this pull request should be accepted.-->

## Checklist

<!--_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. This is simply a reminder of what we are going to look for before merging your code. -->

- [x] I have referenced the Jira issue related to my changes in one or more commit messages
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No Javadoc warnings were introduced with my changes
- [x] No spotbugs warnings were introduced with my changes
- [x] I have interactively tested my changes

## Types of changes

<!--What types of changes does your code introduce? _Put an `x` in the boxes that apply_-->

- [ ] Infrastructure change (non-breaking change which updates dependencies or improves infrastructure)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
