### PR TITLE
Fix saving image files with Image IO

### DIFF
--- a/src/main/java/io/jenkins/plugins/ml/IPythonBuilder.java
+++ b/src/main/java/io/jenkins/plugins/ml/IPythonBuilder.java
@@ -160,6 +160,9 @@ public class IPythonBuilder extends Builder implements SimpleBuildStep, Serializ
                 LOGGER.info("Connection initiated successfully");
                 listener.getLogger().println("Platform : " + System.getProperty("os.name").toUpperCase());
                 listener.getLogger().println("Type : " + parserType.toUpperCase());
+                listener.getLogger().println("Working directory : " + ws.getRemote());
+                // Change working directory as workspace directory
+                interpreterManager.invokeInterpreter("import os\nos.chdir('" + ws.getRemote() + "')", "test", ws);
                 if (parserType.equals("text")) {
                     listener.getLogger().println(interpreterManager.invokeInterpreter(code, task, ws));
                 } else {

--- a/src/main/java/io/jenkins/plugins/ml/IPythonInterpreterManager.java
+++ b/src/main/java/io/jenkins/plugins/ml/IPythonInterpreterManager.java
@@ -108,6 +108,10 @@ public class IPythonInterpreterManager extends InterpreterManager {
     protected String invokeInterpreter(String code, String task, FilePath workspace)
             throws InterpreterException, IOException, InterruptedException {
         List<InterpreterResultMessage> interpreterResultMessages = kernelInterpreter.interpretCode(code);
+        if (interpreterResultMessages == null) {
+            LOGGER.info("Returning empty message for non-output code");
+            return "";
+        }
         boolean containsHTML = false;
         StringBuilder strTEXTBuild = new StringBuilder();
         StringBuilder strHTMLBuild = new StringBuilder();

--- a/src/main/java/io/jenkins/plugins/ml/utils/Dumper.java
+++ b/src/main/java/io/jenkins/plugins/ml/utils/Dumper.java
@@ -34,6 +34,8 @@ import java.awt.image.BufferedImage;
 import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 
@@ -83,7 +85,11 @@ public final class Dumper {
 
         /* read decoded image data */
         BufferedImage img = ImageIO.read(new ByteArrayInputStream(imageBytes));
-        ImageIO.write(img, "png", new File(dumpPath.getRemote()));
+        File imgFile = new File(dumpPath.getRemote());
+        if (!imgFile.getParentFile().exists()) {
+            Files.createDirectories(Paths.get(imgFile.getParent()));
+        }
+        ImageIO.write(img, "png", imgFile);
         LOGGER.info("Success");
   }
 }


### PR DESCRIPTION
## [JENKINS-63278](https://issues.jenkins-ci.org/browse/JENKINS-63278) - Fix some minor bugs

- Fix bug when saving image files before creating the folder/file.
- Fix null pointer exception when returning empty messages from the output( Eg: a = 10)
- Change the working directory to workspace directory using the python interpreter

<!--Describe the big picture of your changes here to explain to the maintainers why this pull request should be accepted.-->

## Checklist

<!--_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. This is simply a reminder of what we are going to look for before merging your code. -->

- [x] I have referenced the Jira issue related to my changes in one or more commit messages
- [x] Unit tests pass locally with my changes
- [ ] I have added documentation as necessary
- [x] No Javadoc warnings were introduced with my changes
- [x] No spotbugs warnings were introduced with my changes
- [x] I have interactively tested my changes

## Types of changes

<!--What types of changes does your code introduce? _Put an `x` in the boxes that apply_-->

- [ ] Infrastructure change (non-breaking change which updates dependencies or improves infrastructure)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

