### PR TITLE
Update Jenkinsfile syntax

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -7,9 +7,9 @@ def testJenkinsVersions = [ '2.204.1', '2.204.6', '2.222.4', '2.235.1', '2.243' 
 Collections.shuffle(testJenkinsVersions)
 
 // Test plugin compatibility to subset of Jenkins versions
-subsetConfiguration = [ [ jdk: '8',  platform: 'windows', jenkins: testJenkinsVersions[0], javaLevel: '8' ],
-                        [ jdk: '8',  platform: 'linux',   jenkins: testJenkinsVersions[1], javaLevel: '8' ],
-                        [ jdk: '11', platform: 'linux',   jenkins: testJenkinsVersions[2], javaLevel: '8' ]
+subsetConfiguration = [ [ jdk: '8',  platform: 'windows', jenkins: testJenkinsVersions[0] ],
+                        [ jdk: '8',  platform: 'linux',   jenkins: testJenkinsVersions[1] ],
+                        [ jdk: '11', platform: 'linux',   jenkins: testJenkinsVersions[2] ]
                       ]
 
 buildPlugin(configurations: subsetConfiguration, failFast: false)


### PR DESCRIPTION
The javaLevel option is deprecated and does no longer set the Java version. The option is ignored.
This PR removes the unused option.